### PR TITLE
Argo CRD is missing when deployed to fresh cluster

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -3,6 +3,7 @@
 # It should be run by config/default
 resources:
 - bases/addonmgr.keikoproj.io_addons.yaml
+- bases/argoproj_v1alpha1_workflows.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 #patchesStrategicMerge:


### PR DESCRIPTION
Add the Argo CRD as part of deployment.