### PR TITLE
Preserve labels in Workflow templates

### DIFF
--- a/pkg/workflows/workflow.go
+++ b/pkg/workflows/workflow.go
@@ -263,16 +263,6 @@ func (w *workflowLifecycle) parse(wt *addonmgrv1alpha1.WorkflowType, wf *unstruc
 		return fmt.Errorf("invalid workflow yaml spec passed. %v", err)
 	}
 
-	// Enforce this to be a workflow type
-	wf.SetGroupVersionKind(schema.GroupVersionKind{
-		Kind:    "Workflow",
-		Group:   "argoproj.io",
-		Version: "v1alpha1",
-	})
-
-	wf.SetNamespace(w.addon.GetNamespace())
-	wf.SetName(name)
-
 	// We need to marshal and unmarshal due to conversion issues.
 	raw, err := json.Marshal(data)
 	if err != nil {
@@ -282,6 +272,16 @@ func (w *workflowLifecycle) parse(wt *addonmgrv1alpha1.WorkflowType, wf *unstruc
 	if err != nil {
 		return errors.New("invalid workflow, unable to unmarshal to workflow")
 	}
+
+	// Enforce this to be a workflow type
+	wf.SetGroupVersionKind(schema.GroupVersionKind{
+		Kind:    "Workflow",
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+	})
+
+	wf.SetNamespace(w.addon.GetNamespace())
+	wf.SetName(name)
 
 	if _, foundSpec, err := unstructured.NestedFieldNoCopy(wf.Object, "spec"); err != nil || !foundSpec {
 		return errors.New("invalid workflow, missing spec")

--- a/pkg/workflows/workflow_test.go
+++ b/pkg/workflows/workflow_test.go
@@ -386,6 +386,11 @@ func TestWorkflowLifecycle_Install_Resources(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(ttl).To(Equal(int64(time.Duration(72 * time.Hour).Seconds())))
 
+		// Verify activeDeadlineSeconds are kept
+		active, found, err := unstructured.NestedInt64(wfv1.UnstructuredContent(), "spec", "activeDeadlineSeconds")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(active).To(Equal(int64(600)))
+
 		// Verify workflow labels are kept
 		labels := wfv1.GetLabels()
 		g.Expect(labels).To(HaveKeyWithValue("workflows.argoproj.io/controller-instanceid", "addon-manager-workflow-controller"))
@@ -473,6 +478,11 @@ func TestWorkflowLifecycle_Install_Artifacts(t *testing.T) {
 		ttl, found, err := unstructured.NestedInt64(wfv1.UnstructuredContent(), "spec", "ttlSecondsAfterFinished")
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(ttl).To(Equal(int64(time.Duration(72 * time.Hour).Seconds())))
+
+		// Verify activeDeadlineSeconds are kept
+		active, found, err := unstructured.NestedInt64(wfv1.UnstructuredContent(), "spec", "activeDeadlineSeconds")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(active).To(Equal(int64(600)))
 
 		// Verify workflow labels are kept
 		labels := wfv1.GetLabels()

--- a/pkg/workflows/workflow_test.go
+++ b/pkg/workflows/workflow_test.go
@@ -41,40 +41,6 @@ var fclient = runtimefake.NewFakeClientWithScheme(sch)
 var dynClient = dynfake.NewSimpleDynamicClient(sch)
 var rcdr = record.NewBroadcasterForTests(1*time.Second).NewRecorder(sch, v1.EventSource{Component: "addons"})
 
-var wfDeleteTemplatePanic = `
-        apiVersion: argoproj.io/v1alpha1
-        kind: Workflow
-        metadata:
-          labels:
-            workflows.argoproj.io/controller-instanceid: addon-manager-workflow-controller
-        spec:
-          activeDeadlineSeconds: 600
-          entrypoint: delete-wf
-          serviceAccountName: addon-manager-workflow-installer-sa
-
-          templates:
-            - name: delete-wf
-              steps:
-                - - name: delete-ns
-                    template: delete-ns
-              tolerations:
-              - key: node-role.kubernetes.io/system
-                effect: NoSchedule
-              nodeSelector:
-                node-role.kubernetes.io/system: ""
-
-            - name: delete-ns
-              tolerations:
-              - key: node-role.kubernetes.io/system
-                effect: NoSchedule
-              nodeSelector:
-                node-role.kubernetes.io/system: ""
-              container:
-                image: docker.artifactory.a.intuit.com/expert360/kubectl-awscli:v1.11.2
-                command: [sh, -c]
-                args: ["kubectl delete all -n {{workflow.parameters.namespace}} --all"]
-`
-
 var wfInvalidTemplate = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
@@ -87,6 +53,7 @@ metadata:
   labels:
     workflows.argoproj.io/controller-instanceid: addon-manager-workflow-controller
 spec:
+  activeDeadlineSeconds: 600
   entrypoint: entry
   serviceAccountName: addon-manager-workflow-installer-sa
   templates:
@@ -137,6 +104,7 @@ metadata:
   labels:
     workflows.argoproj.io/controller-instanceid: addon-manager-workflow-controller
 spec:
+  activeDeadlineSeconds: 600
   entrypoint: entry
   serviceAccountName: addon-manager-workflow-installer-sa
   templates:
@@ -200,6 +168,7 @@ metadata:
   labels:
     workflows.argoproj.io/controller-instanceid: addon-manager-workflow-controller
 spec:
+  activeDeadlineSeconds: 600
   entrypoint: entry
   serviceAccountName: addon-manager-workflow-installer-sa
   templates:
@@ -697,41 +666,4 @@ func TestNewWorkflowLifecycle_Delete(t *testing.T) {
 
 	// Now try to delete
 	g.Expect(wfl.Delete("addon-wf-test")).To(Not(HaveOccurred()))
-}
-
-func TestWorkflowLifecycle_Install_PanicWorkflowTemplate(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	a := &v1alpha1.Addon{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
-			Namespace: "default",
-		},
-		Spec: v1alpha1.AddonSpec{
-			PackageSpec: v1alpha1.PackageSpec{
-				PkgName:        "my-addon",
-				PkgVersion:     "1.0.0",
-				PkgType:        v1alpha1.HelmPkg,
-				PkgDescription: "",
-				PkgDeps:        map[string]string{"core/A": "*", "core/B": "v1.0.0"},
-			},
-			Selector: metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app": "my-app",
-				},
-			},
-		},
-	}
-
-	wfl := NewWorkflowLifecycle(dynClient, a, rcdr, sch)
-
-	// Workflow missing "spec" should fail
-	wt := &v1alpha1.WorkflowType{
-		Template: wfDeleteTemplatePanic,
-	}
-
-	phase, err := wfl.Install(context.Background(), wt, "addon-wf-test")
-
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(phase).To(Equal(v1alpha1.Failed))
 }


### PR DESCRIPTION
Fixes missing workflow labels from template to deployment. Labels are now preserved.

```yaml
apiVersion: addonmgr.keikoproj.io/v1alpha1
kind: Addon
spec:
  lifecycle:
    install:
      template: |
        apiVersion: argoproj.io/v1alpha1
        kind: Workflow
        metadata:
          labels:
            workflows.argoproj.io/controller-instanceid: addon-manager-workflow-controller
...
```

Workflow Deployment Ex.
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  labels:
    workflows.argoproj.io/controller-instanceid: addon-manager-workflow-controller
spec:
```

