### PR TITLE
Remove "v" prefix from snapshot version binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,7 +54,7 @@ changelog:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "v{{ .Major }}.{{ .Minor }}-snapshot-{{ .ShortCommit }}"
+  name_template: "{{ .Major }}.{{ .Minor }}-snapshot-{{ .ShortCommit }}"
 
 dockers:
   - goos: linux


### PR DESCRIPTION
Removes the "v" prefix from snapshot binary names, fixes double "v" in docker tags.