### PR TITLE
Remove version labels

### DIFF
--- a/config/argo/kustomization.yaml
+++ b/config/argo/kustomization.yaml
@@ -4,6 +4,5 @@ resources:
   - argo.yaml
 commonLabels:
   app.kubernetes.io/name: addon-manager-argo-addon
-  app.kubernetes.io/version: "v2.11.0"
   app.kubernetes.io/part-of: addon-manager-argo-addon
   app.kubernetes.io/managed-by: addonmgr.keikoproj.io


### PR DESCRIPTION
Removing common version labels as Kustomize will also add these to the selectors which are immutable then we get into updating problems.