### PR TITLE
Hotfix/v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+<a name="v0.3.0"></a>
+## [v0.3.0] - 2020-09-23
+### Fixed
+- Change Failed status to Pending for dependant addons (#63)
+- Upgrade Argo and inject deadline for workflows. (#64) (#69)
+### Changed
+- Various improvements (#60) (#61) (#62)
+
 <a name="v0.2.1"></a>
 ## [v0.2.1] - 2020-04-13
 ### Fixed
@@ -34,7 +42,8 @@
 ### Added
 - Initial Release of Addon Manager
 
-[Unreleased]: https://github.com/keikoproj/addon-manager/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/keikoproj/addon-manager/compare/v0.3.0...HEAD
+[v0.3.0]: https://github.com/keikoproj/addon-manager/compare/v0.3.0...v0.2.1
 [v0.2.1]: https://github.com/keikoproj/addon-manager/compare/v0.2.0...v0.2.1
 [v0.2.0]: https://github.com/keikoproj/addon-manager/compare/v0.1.0...v0.2.0
 [v0.1.0]: https://github.com/keikoproj/addon-manager/compare/v0.1.0...v0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+<a name="v0.3.1"></a>
+## [v0.3.1] - 2020-10-06
+### Fixed
+- Upgrade Argo to v2.11.1 (#72)
+- Improve Watchers to only look for owned resources (#72)
+
 <a name="v0.3.0"></a>
 ## [v0.3.0] - 2020-09-23
 ### Fixed
@@ -42,7 +48,8 @@
 ### Added
 - Initial Release of Addon Manager
 
-[Unreleased]: https://github.com/keikoproj/addon-manager/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/keikoproj/addon-manager/compare/v0.3.1...HEAD
+[v0.3.1]: https://github.com/keikoproj/addon-manager/compare/v0.3.0...v0.3.1
 [v0.3.0]: https://github.com/keikoproj/addon-manager/compare/v0.3.0...v0.2.1
 [v0.2.1]: https://github.com/keikoproj/addon-manager/compare/v0.2.0...v0.2.1
 [v0.2.0]: https://github.com/keikoproj/addon-manager/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Fixed
 - Upgrade Argo to v2.11.1 (#72)
 - Improve Watchers to only look for owned resources (#72)
+### Changed
+- Remove common app.kubernetes.io/version labels from Kustomize (#71)
 
 <a name="v0.3.0"></a>
 ## [v0.3.0] - 2020-09-23

--- a/config/argo/argo.yaml
+++ b/config/argo/argo.yaml
@@ -163,11 +163,11 @@ spec:
             - --configmap
             - addon-manager-workflow-controller-configmap
             - --executor-image
-            - argoproj/argoexec:v2.11.0
+            - argoproj/argoexec:v2.11.1
             - --namespaced
           command:
             - workflow-controller
-          image: argoproj/workflow-controller:v2.11.0
+          image: argoproj/workflow-controller:v2.11.1
           name: workflow-controller
       serviceAccountName: argo
 ---
@@ -178,7 +178,7 @@ metadata:
   namespace: system
 spec:
   pkgName: addon-argo-workflow
-  pkgVersion: v2.11.0
+  pkgVersion: v2.11.1
   pkgType: composite
   pkgDescription: "Argo Workflow Controller for Addon Controller."
   params:

--- a/config/argo/kustomization.yaml
+++ b/config/argo/kustomization.yaml
@@ -4,6 +4,5 @@ resources:
   - argo.yaml
 commonLabels:
   app.kubernetes.io/name: addon-manager-argo-addon
-  app.kubernetes.io/version: "v2.11.0"
   app.kubernetes.io/part-of: addon-manager-argo-addon
   app.kubernetes.io/managed-by: addonmgr.keikoproj.io

--- a/controllers/addon_controller.go
+++ b/controllers/addon_controller.go
@@ -146,14 +146,10 @@ func (r *AddonReconciler) execAddon(ctx context.Context, req reconcile.Request, 
 // SetupWithManager is called to setup manager and watchers
 func (r *AddonReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	log := r.Log
-	//var addongrp = common.AddonGVR().Group
 	bldr := ctrl.NewControllerManagedBy(mgr).
 		For(&addonmgrv1alpha1.Addon{}).
 		// Watch workflows created by addon
-		Watches(&source.Kind{Type: common.WorkflowType()}, &handler.EnqueueRequestForOwner{
-			IsController: false,
-			OwnerType:    &addonmgrv1alpha1.Addon{},
-		})
+		Owns(common.WorkflowType())
 
 	generatedInformers = informers.NewSharedInformerFactory(r.generatedClient, time.Minute*30)
 

--- a/pkg/workflows/workflow.go
+++ b/pkg/workflows/workflow.go
@@ -249,13 +249,6 @@ func (w *workflowLifecycle) submit(ctx context.Context, wp *unstructured.Unstruc
 		if err := controllerutil.SetControllerReference(w.addon, wfv1, w.scheme); err != nil {
 			return addonmgrv1alpha1.Failed, err
 		}
-		ownerReferences := wfv1.GetOwnerReferences()
-		for _, ref := range ownerReferences {
-			if strings.ToLower(ref.Kind) == "addon" {
-				*ref.Controller = false
-			}
-		}
-		wfv1.SetOwnerReferences(ownerReferences)
 
 		err = w.Create(ctx, wfv1)
 		if err != nil {


### PR DESCRIPTION
Uptakes latest hotfix from Argo [v2.11.1](https://github.com/argoproj/argo/releases/tag/v2.11.1)

Also tweaks the watchers to only look at owned resources.