### PR TITLE
Execute Argoworkflow after spec change

### DIFF
--- a/controllers/addon_controller.go
+++ b/controllers/addon_controller.go
@@ -212,7 +212,7 @@ func (r *AddonReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Request, log logr.Logger, instance *addonmgrv1alpha1.Addon) (reconcile.Result, error) {
 
-	// Calculate Checksum
+	// Calculate Checksum, returns true if checksum is not changed
 	var checkSumStatus bool
 	checkSumStatus, instance.Status.Checksum = r.validateChecksum(instance)
 

--- a/controllers/addon_controller.go
+++ b/controllers/addon_controller.go
@@ -325,6 +325,8 @@ func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Reques
 	// Execute PreReq and Install workflow, if spec body has changed.
 	// Also if workflow is in Pending state, execute it to update status to terminal state.
 	if changedStatus || instance.Status.Lifecycle.Prereqs == addonmgrv1alpha1.Pending || instance.Status.Lifecycle.Installed == addonmgrv1alpha1.Pending {
+		log.Info("Addon spec is updated, workflows will be generated")
+
 		err := r.executePrereqAndInstall(ctx, log, instance, wfl)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -410,6 +412,8 @@ func (r *AddonReconciler) updateAddonStatus(ctx context.Context, log logr.Logger
 		r.recorder.Event(addon, "Warning", "Failed", fmt.Sprintf("Addon %s/%s status could not be updated. %v", addon.Namespace, addon.Name, err))
 		return err
 	}
+
+
 
 	return nil
 }

--- a/controllers/addon_controller.go
+++ b/controllers/addon_controller.go
@@ -364,7 +364,7 @@ func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Reques
 			return reconcile.Result{}, err
 		}
 
-		// Update only if spec Body is changed
+		// Update only if spec Body is change, this is to make sure any intended drift is retained
 		if !checkSumStatus {
 			phase, err := r.runWorkflow(addonmgrv1alpha1.Install, instance, wfl)
 			instance.Status.Lifecycle.Installed = phase


### PR DESCRIPTION
Fixes #74 

Currently, Argoworkflow is executed after every `ttlSecondsAfterFinished` after Argo controller deletes the workflow. Addon manager reapplies the CR. This is particularly causing problems when there is a intended drift which gets updated.

Default value of `ttlSecondsAfterFinished` is 74hrs. 
https://github.com/keikoproj/addon-manager/blob/master/pkg/workflows/workflow.go#L518

With this PR, we make sure add-on manager can only execute the prereq and install workflows only if there is Checksum change.

Testing done.
- [x] Controller not re-creating the workflows after delete.
- [x] After 72hrs, no workflow is present in `kubectl get wf -n addon-manager-system`

