### PR TITLE
Execute workflow for checksum change only

### DIFF
--- a/controllers/addon_controller.go
+++ b/controllers/addon_controller.go
@@ -212,8 +212,9 @@ func (r *AddonReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Request, log logr.Logger, instance *addonmgrv1alpha1.Addon) (reconcile.Result, error) {
 
-	// Calculate Checksum
-	instance.Status.Checksum = instance.CalculateChecksum()
+	// Calculate Checksum, returns true if checksum is not changed
+	var changedStatus bool
+	changedStatus, instance.Status.Checksum = r.validateChecksum(instance)
 
 	// Resources list
 	instance.Status.Resources = make([]addonmgrv1alpha1.ObjectStatus, 0)
@@ -321,60 +322,15 @@ func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Reques
 	// Add addon to cache
 	//r.addAddonToCache(req, addon, addonmgrv1alpha1.Pending)
 
-	// Prereqs workflow
-	prereqsPhase, err := r.runWorkflow(addonmgrv1alpha1.Prereqs, instance, wfl)
-	instance.Status.Lifecycle.Prereqs = prereqsPhase
-	if err != nil {
-		reason := fmt.Sprintf("Addon %s/%s prereqs failed. %v", instance.Namespace, instance.Name, err)
-		r.recorder.Event(instance, "Warning", "Failed", reason)
-		log.Error(err, "Addon prereqs workflow failed.")
-		// if prereqs failed, set install status to failed as well so that STATUS is updated
-		instance.Status.Lifecycle.Installed = addonmgrv1alpha1.Failed
-		instance.Status.StartTime = 0
-		instance.Status.Reason = reason
+	// Execute PreReq and Install workflow, if spec body has changed.
+	// Also if workflow is in Pending state, execute it to update status to terminal state.
+	if changedStatus || instance.Status.Lifecycle.Prereqs == addonmgrv1alpha1.Pending || instance.Status.Lifecycle.Installed == addonmgrv1alpha1.Pending {
+		log.Info("Addon spec is updated, workflows will be generated")
 
-		return reconcile.Result{}, err
-	}
-
-	//handle Prereqs failure
-	if instance.Status.Lifecycle.Prereqs == addonmgrv1alpha1.Failed {
-		reason := fmt.Sprintf("Addon %s/%s Prereqs status is Failed", instance.Namespace, instance.Name)
-		r.recorder.Event(instance, "Warning", "Failed", reason)
-		log.Error(err, "Addon prereqs workflow failed.")
-		// if prereqs failed, set install status to failed as well so that STATUS is updated
-		instance.Status.Lifecycle.Installed = addonmgrv1alpha1.Failed
-		instance.Status.StartTime = 0
-		instance.Status.Reason = reason
-
-		return reconcile.Result{}, fmt.Errorf(reason)
-	}
-
-	// Validate secrets are in the addon deployment namespace, this is here and not in validator b/c namespace must be used to validate.
-	if instance.Status.Lifecycle.Prereqs == addonmgrv1alpha1.Succeeded {
-		if err := r.validateSecrets(ctx, instance); err != nil {
-			reason := fmt.Sprintf("Addon %s/%s could not validate secrets. %v", instance.Namespace, instance.Name, err)
-			r.recorder.Event(instance, "Warning", "Failed", reason)
-			log.Error(err, "Addon could not validate secrets.")
-			instance.Status.Lifecycle.Installed = addonmgrv1alpha1.Failed
-			instance.Status.StartTime = 0
-			instance.Status.Reason = reason
-
-			return reconcile.Result{}, err
-		}
-
-		phase, err := r.runWorkflow(addonmgrv1alpha1.Install, instance, wfl)
-		instance.Status.Lifecycle.Installed = phase
+		err := r.executePrereqAndInstall(ctx, log, instance, wfl)
 		if err != nil {
-			reason := fmt.Sprintf("Addon %s/%s could not be installed due to error. %v", instance.Namespace, instance.Name, err)
-			r.recorder.Event(instance, "Warning", "Failed", reason)
-			log.Error(err, "Addon install workflow failed.")
-			instance.Status.StartTime = 0
-			instance.Status.Reason = reason
-
 			return reconcile.Result{}, err
 		}
-
-		//r.addAddonToCache(req, instance, phase)
 	}
 
 	// Observe resources matching selector labels.
@@ -457,6 +413,8 @@ func (r *AddonReconciler) updateAddonStatus(ctx context.Context, log logr.Logger
 		return err
 	}
 
+
+
 	return nil
 }
 
@@ -468,6 +426,63 @@ func (r *AddonReconciler) addAddonToCache(instance *addonmgrv1alpha1.Addon) {
 		PkgPhase:    instance.GetInstallStatus(),
 	}
 	r.versionCache.AddVersion(version)
+}
+
+func (r *AddonReconciler) executePrereqAndInstall(ctx context.Context, log logr.Logger, instance *addonmgrv1alpha1.Addon, wfl workflows.AddonLifecycle) error {
+
+	prereqsPhase, err := r.runWorkflow(addonmgrv1alpha1.Prereqs, instance, wfl)
+	if err != nil {
+		reason := fmt.Sprintf("Addon %s/%s prereqs failed. %v", instance.Namespace, instance.Name, err)
+		r.recorder.Event(instance, "Warning", "Failed", reason)
+		log.Error(err, "Addon prereqs workflow failed.")
+		// if prereqs failed, set install status to failed as well so that STATUS is updated
+		instance.Status.Lifecycle.Installed = addonmgrv1alpha1.Failed
+		instance.Status.StartTime = 0
+		instance.Status.Reason = reason
+
+		return err
+	}
+	instance.Status.Lifecycle.Prereqs = prereqsPhase
+
+	//handle Prereqs failure
+	if instance.Status.Lifecycle.Prereqs == addonmgrv1alpha1.Failed {
+		reason := fmt.Sprintf("Addon %s/%s Prereqs status is Failed", instance.Namespace, instance.Name)
+		log.Error(err, "Addon prereqs workflow failed.")
+		r.recorder.Event(instance, "Warning", "Failed", reason)
+		// if prereqs failed, set install status to failed as well so that STATUS is updated
+		instance.Status.Lifecycle.Installed = addonmgrv1alpha1.Failed
+		instance.Status.StartTime = 0
+		instance.Status.Reason = reason
+
+		return fmt.Errorf(reason)
+	}
+
+	if instance.Status.Lifecycle.Prereqs == addonmgrv1alpha1.Succeeded {
+		if err := r.validateSecrets(ctx, instance); err != nil {
+			reason := fmt.Sprintf("Addon %s/%s could not validate secrets. %v", instance.Namespace, instance.Name, err)
+			r.recorder.Event(instance, "Warning", "Failed", reason)
+			log.Error(err, "Addon could not validate secrets.")
+			instance.Status.Lifecycle.Installed = addonmgrv1alpha1.Failed
+			instance.Status.StartTime = 0
+			instance.Status.Reason = reason
+
+			return err
+		}
+
+		phase, err := r.runWorkflow(addonmgrv1alpha1.Install, instance, wfl)
+		instance.Status.Lifecycle.Installed = phase
+		if err != nil {
+			reason := fmt.Sprintf("Addon %s/%s could not be installed due to error. %v", instance.Namespace, instance.Name, err)
+			r.recorder.Event(instance, "Warning", "Failed", reason)
+			log.Error(err, "Addon install workflow failed.")
+			instance.Status.StartTime = 0
+			instance.Status.Reason = reason
+
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (r *AddonReconciler) observeResources(ctx context.Context, a *addonmgrv1alpha1.Addon) ([]addonmgrv1alpha1.ObjectStatus, error) {
@@ -518,6 +533,17 @@ func (r *AddonReconciler) observeResources(ctx context.Context, a *addonmgrv1alp
 	}
 
 	return observed, nil
+}
+
+// Calculates new checksum and validates if there is a diff
+func (r *AddonReconciler) validateChecksum(instance *addonmgrv1alpha1.Addon) (bool, string) {
+	newCheckSum := instance.CalculateChecksum()
+
+	if instance.Status.Checksum == newCheckSum {
+		return false, newCheckSum
+	}
+
+	return true, newCheckSum
 }
 
 // Finalize runs finalizer for addon


### PR DESCRIPTION
Fixes #74 

Currently, Argoworkflow is executed after every `ttlSecondsAfterFinished` after Argo controller deletes the workflow. Addon manager reapplies the CR. This is particularly causing problems when there is a intended drift which gets updated.

Default value of `ttlSecondsAfterFinished` is 74hrs. 
https://github.com/keikoproj/addon-manager/blob/master/pkg/workflows/workflow.go#L518

With this PR, we make sure add-on manager can only execute the prereq and install workflows only if there is Checksum change.

Testing done.
- [x] Controller not re-creating the workflows after delete.
- [x] After 72hrs, no workflow is present in `kubectl get wf -n addon-manager-system`

Signed-off-by: lostbrain101 <aakash_chandrasekaran@intuit.com>