### PR TITLE
Always reset the timer whenever checksum changes

### DIFF
--- a/controllers/addon_controller.go
+++ b/controllers/addon_controller.go
@@ -220,8 +220,8 @@ func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Reques
 	// Resources list
 	instance.Status.Resources = make([]addonmgrv1alpha1.ObjectStatus, 0)
 
-	// Set ttl starttime if it is 0
-	if instance.Status.StartTime == 0 {
+	// Set ttl starttime if checksum has changed
+	if changedStatus {
 		instance.Status.StartTime = common.GetCurretTimestamp()
 	}
 
@@ -244,7 +244,6 @@ func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Reques
 
 		instance.Status.Lifecycle.Installed = addonmgrv1alpha1.Failed
 		instance.Status.Reason = reason
-		instance.Status.StartTime = 0
 
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
Fixes the flapping that might happen when TTL expired is detected. Since before we never updated `.status.starttime` all older addons would be always expired and flap once.

```
alb-ingress-controller     alb-ingress-controller     v0.4      Failed               5h2m
```

```
{"level":"error","ts":1623181250.545077,"logger":"controllers.Addon","msg":"Addon addon-manager-system/alb-ingress-controller ttl expired","addon":"addon-manager-system/alb-ingress-controller","error":"Addon addon-manager-system/alb-ingress-controller ttl expired","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/kdowney/go/pkg/mod/github.com/go-logr/zapr@v0.2.0/zapr.go:132\ngithub.com/keikoproj/addon-manager/controllers.(*AddonReconciler).processAddon\n\t/Users/kdowney/go/src/github.com/keikoproj/addon-manager/controllers/addon_controller.go:242\ngithub.com/keikoproj/addon-manager/controllers.(*AddonReconciler).execAddon\n\t/Users/kdowney/go/src/github.com/keikoproj/addon-manager/controllers/addon_controller.go:132\ngithub.com/keikoproj/addon-manager/controllers.(*AddonReconciler).Reconcile\n\t/Users/kdowney/go/src/github.com/keikoproj/addon-manager/controllers/addon_controller.go:122\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/Users/kdowney/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.5/pkg/internal/controller/controller.go:244\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/kdowney/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.5/pkg/internal/controller/controller.go:218\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/Users/kdowney/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.5/pkg/internal/controller/controller.go:197\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/Users/kdowney/go/pkg/mod/k8s.io/apimachinery@v0.19.11/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/Users/kdowney/go/pkg/mod/k8s.io/apimachinery@v0.19.11/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/Users/kdowney/go/pkg/mod/k8s.io/apimachinery@v0.19.11/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/Users/kdowney/go/pkg/mod/k8s.io/apimachinery@v0.19.11/pkg/util/wait/wait.go:90"}
```


Signed-off-by: Kevin D <kevdowney@gmail.com>