### PR TITLE
Hotfix v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+<a name="v0.4.1"></a>
+## [v0.4.1] - 2021-06-08
+### Changed
+- Add a conflict retry on status updates (#82)
+- Always reset the timer whenever checksum changes (#83)
+
 <a name="v0.4.0"></a>
 ## [v0.4.0] - 2021-06-07
 ### Changed
@@ -56,7 +62,8 @@
 ### Added
 - Initial Release of Addon Manager
 
-[Unreleased]: https://github.com/keikoproj/addon-manager/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/keikoproj/addon-manager/compare/v0.4.1...HEAD
+[v0.4.1]: https://github.com/keikoproj/addon-manager/compare/v0.4.0...v0.4.1
 [v0.4.0]: https://github.com/keikoproj/addon-manager/compare/v0.3.1...v0.4.0
 [v0.3.1]: https://github.com/keikoproj/addon-manager/compare/v0.3.0...v0.3.1
 [v0.3.0]: https://github.com/keikoproj/addon-manager/compare/v0.3.0...v0.2.1

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,7 +19,7 @@ import "fmt"
 // The below variables will be overrriden using ldflags set by goreleaser during the build process
 var (
 	// Version is the version string
-	Version = "v0.4.0"
+	Version = "v0.4.1"
 
 	// GitCommit is the git commit hash
 	GitCommit = "NONE"


### PR DESCRIPTION
## [v0.4.1] - 2021-06-08
### Changed
- Add a conflict retry on status updates (#82)
- Always reset the timer whenever checksum changes (#83)



Signed-off-by: Kevin D <kevdowney@gmail.com>