### PR TITLE
Increase Addon TTL to 1-hour and reset status per checksum change

### DIFF
--- a/api/v1alpha1/addon_types.go
+++ b/api/v1alpha1/addon_types.go
@@ -280,7 +280,7 @@ type AddonStatus struct {
 	Lifecycle AddonStatusLifecycle `json:"lifecycle"`
 	Resources []ObjectStatus       `json:"resources"`
 	Reason    string               `json:"reason"`
-	StartTime int64                `json:"starttime,omitempty"`
+	StartTime int64                `json:"starttime"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/addonmgr.keikoproj.io_addons.yaml
+++ b/config/crd/bases/addonmgr.keikoproj.io_addons.yaml
@@ -355,6 +355,7 @@ spec:
             - lifecycle
             - reason
             - resources
+            - starttime
             type: object
         type: object
     served: true

--- a/controllers/addon_controller.go
+++ b/controllers/addon_controller.go
@@ -240,7 +240,7 @@ func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Reques
 
 	// Check if addon installation expired.
 	if instance.Status.Lifecycle.Installed == addonmgrv1alpha1.Pending && common.IsExpired(instance.Status.StartTime, TTL) {
-		reason := fmt.Sprintf("Addon %s/%s ttl expired", instance.Namespace, instance.Name)
+		reason := fmt.Sprintf("Addon %s/%s ttl expired, starttime was %d", instance.Namespace, instance.Name, instance.Status.StartTime)
 		r.recorder.Event(instance, "Warning", "Failed", reason)
 		err := fmt.Errorf(reason)
 		log.Error(err, reason)

--- a/controllers/addon_controller.go
+++ b/controllers/addon_controller.go
@@ -53,7 +53,7 @@ import (
 )
 
 // addon ttl time
-const TTL int64 = 180000
+const TTL int64 = int64((time.Duration(1) * time.Hour)/time.Millisecond) // 1 hour
 
 // Watched resources
 var (

--- a/controllers/addon_controller.go
+++ b/controllers/addon_controller.go
@@ -53,7 +53,7 @@ import (
 )
 
 // addon ttl time
-const TTL int64 = int64((time.Duration(1) * time.Hour)/time.Millisecond) // 1 hour
+const TTL int64 = int64((time.Duration(1) * time.Hour) / time.Millisecond) // 1 hour
 
 // Watched resources
 var (

--- a/controllers/addon_controller.go
+++ b/controllers/addon_controller.go
@@ -53,7 +53,7 @@ import (
 )
 
 // addon ttl time
-const TTL int64 = int64((time.Duration(1) * time.Hour) / time.Millisecond) // 1 hour
+const TTL = time.Duration(1) * time.Hour // 1 hour
 
 // Watched resources
 var (
@@ -241,8 +241,8 @@ func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Reques
 	}
 
 	// Check if addon installation expired.
-	if instance.Status.Lifecycle.Installed == addonmgrv1alpha1.Pending && common.IsExpired(instance.Status.StartTime, TTL) {
-		reason := fmt.Sprintf("Addon %s/%s ttl expired, starttime was %d", instance.Namespace, instance.Name, instance.Status.StartTime)
+	if instance.Status.Lifecycle.Installed == addonmgrv1alpha1.Pending && common.IsExpired(instance.Status.StartTime, TTL.Milliseconds()) {
+		reason := fmt.Sprintf("Addon %s/%s ttl expired, starttime exceeded %s", instance.Namespace, instance.Name, TTL.String())
 		r.recorder.Event(instance, "Warning", "Failed", reason)
 		err := fmt.Errorf(reason)
 		log.Error(err, reason)

--- a/controllers/addon_controller.go
+++ b/controllers/addon_controller.go
@@ -223,13 +223,15 @@ func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Reques
 	// Resources list
 	instance.Status.Resources = make([]addonmgrv1alpha1.ObjectStatus, 0)
 
-	// Set ttl starttime if checksum has changed
 	if changedStatus {
+		// Set ttl starttime if checksum has changed
 		instance.Status.StartTime = common.GetCurretTimestamp()
-	}
 
-	// Clear out the reason
-	instance.Status.Reason = ""
+		// Clear out status and reason
+		instance.Status.Lifecycle.Prereqs = ""
+		instance.Status.Lifecycle.Installed = ""
+		instance.Status.Reason = ""
+	}
 
 	// Update status that we have started reconciling this addon.
 	if instance.Status.Lifecycle.Installed == "" {

--- a/controllers/addon_controller.go
+++ b/controllers/addon_controller.go
@@ -264,7 +264,6 @@ func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Reques
 			reason := fmt.Sprintf("Addon %s/%s could not be finalized. %v", instance.Namespace, instance.Name, err)
 			r.recorder.Event(instance, "Warning", "Failed", reason)
 			instance.Status.Lifecycle.Installed = addonmgrv1alpha1.DeleteFailed
-			instance.Status.StartTime = 0
 			instance.Status.Reason = reason
 			log.Error(err, "Failed to finalize addon.")
 			return reconcile.Result{}, err
@@ -281,7 +280,6 @@ func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Reques
 			// Record an event if addon is not valid
 			r.recorder.Event(instance, "Normal", "Pending", reason)
 			instance.Status.Lifecycle.Installed = addonmgrv1alpha1.Pending
-			instance.Status.StartTime = 0
 			instance.Status.Reason = reason
 
 			log.Info("Addon %s/%s is waiting on dependencies to be out of Pending state.", instance.Namespace, instance.Name)
@@ -297,7 +295,6 @@ func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Reques
 		// Record an event if addon is not valid
 		r.recorder.Event(instance, "Warning", "Failed", reason)
 		instance.Status.Lifecycle.Installed = addonmgrv1alpha1.Failed
-		instance.Status.StartTime = 0
 		instance.Status.Reason = reason
 
 		log.Error(err, "Failed to validate addon.")
@@ -314,7 +311,6 @@ func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Reques
 		r.recorder.Event(instance, "Warning", "Failed", reason)
 		log.Error(err, "Failed to add finalizer for addon.")
 		instance.Status.Lifecycle.Installed = addonmgrv1alpha1.Failed
-		instance.Status.StartTime = 0
 		instance.Status.Reason = reason
 		return reconcile.Result{}, err
 	}
@@ -340,7 +336,6 @@ func (r *AddonReconciler) processAddon(ctx context.Context, req reconcile.Reques
 		r.recorder.Event(instance, "Warning", "Failed", reason)
 		log.Error(err, "Addon failed to find deployed resources.")
 		instance.Status.Lifecycle.Installed = addonmgrv1alpha1.Failed
-		instance.Status.StartTime = 0
 		instance.Status.Reason = reason
 
 		return reconcile.Result{}, err
@@ -438,7 +433,6 @@ func (r *AddonReconciler) executePrereqAndInstall(ctx context.Context, log logr.
 		log.Error(err, "Addon prereqs workflow failed.")
 		// if prereqs failed, set install status to failed as well so that STATUS is updated
 		instance.Status.Lifecycle.Installed = addonmgrv1alpha1.Failed
-		instance.Status.StartTime = 0
 		instance.Status.Reason = reason
 
 		return err
@@ -452,7 +446,6 @@ func (r *AddonReconciler) executePrereqAndInstall(ctx context.Context, log logr.
 		r.recorder.Event(instance, "Warning", "Failed", reason)
 		// if prereqs failed, set install status to failed as well so that STATUS is updated
 		instance.Status.Lifecycle.Installed = addonmgrv1alpha1.Failed
-		instance.Status.StartTime = 0
 		instance.Status.Reason = reason
 
 		return fmt.Errorf(reason)
@@ -464,7 +457,6 @@ func (r *AddonReconciler) executePrereqAndInstall(ctx context.Context, log logr.
 			r.recorder.Event(instance, "Warning", "Failed", reason)
 			log.Error(err, "Addon could not validate secrets.")
 			instance.Status.Lifecycle.Installed = addonmgrv1alpha1.Failed
-			instance.Status.StartTime = 0
 			instance.Status.Reason = reason
 
 			return err
@@ -476,7 +468,6 @@ func (r *AddonReconciler) executePrereqAndInstall(ctx context.Context, log logr.
 			reason := fmt.Sprintf("Addon %s/%s could not be installed due to error. %v", instance.Namespace, instance.Name, err)
 			r.recorder.Event(instance, "Warning", "Failed", reason)
 			log.Error(err, "Addon install workflow failed.")
-			instance.Status.StartTime = 0
 			instance.Status.Reason = reason
 
 			return err


### PR DESCRIPTION
Fixes Addon reconciliation by changing the following:
- `.status.startime` is now required
- All status is reset whenever checksum changes
- Status updates are now gated per addon, prevents conflicts
- TTL is increased to `1 Hour`