### PR TITLE
Bump version and CHANGELOG for v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+<a name="v0.4.3"></a>
+## [v0.4.3] - 2021-07-15
+### Fixed
+- Fix delete flow and add tests (#90)
+### Changed
+- Record Addon dependency validation errors as state (#88)
+- Requeue addon for deps not installed error (#91)
+
 <a name="v0.4.2"></a>
 ## [v0.4.2] - 2021-06-09
 ### Changed

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,7 +19,7 @@ import "fmt"
 // The below variables will be overrriden using ldflags set by goreleaser during the build process
 var (
 	// Version is the version string
-	Version = "v0.4.2"
+	Version = "v0.4.3"
 
 	// GitCommit is the git commit hash
 	GitCommit = "NONE"


### PR DESCRIPTION
## [v0.4.3] - 2021-07-15
### Fixed
- Fix delete flow and add tests (#90)
### Changed
- Record Addon dependency validation errors as state (#88)
- Requeue addon for deps not installed error (#91)

Signed-off-by: Kevin D <kevdowney@gmail.com>