### PR TITLE
Update for v0.5.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,9 @@
 ### Added
 - Initial Release of Addon Manager
 
-[Unreleased]: https://github.com/keikoproj/addon-manager/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/keikoproj/addon-manager/compare/v0.5.0...HEAD
+[v0.5.0]: https://github.com/keikoproj/addon-manager/compare/v0.4.3...v0.5.0
+[v0.4.3]: https://github.com/keikoproj/addon-manager/compare/v0.4.2...v0.4.3
 [v0.4.2]: https://github.com/keikoproj/addon-manager/compare/v0.4.1...v0.4.2
 [v0.4.1]: https://github.com/keikoproj/addon-manager/compare/v0.4.0...v0.4.1
 [v0.4.0]: https://github.com/keikoproj/addon-manager/compare/v0.3.1...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 ## [Unreleased]
 
 <a name="v0.5.0"></a>
-## [v0.5.0] - 2022-03-08
+## [v0.5.0] - 2022-04-26
 ### Fixed
 - Build Fix (#102)
+- Fix UTC build date (#135)
 ### Changed
 - Upgrade to Go 1.17+ (#116)
 - Upgrade Kubernetes APIs (apimachinery, api, etc.) to 0.21 (#116)
@@ -15,6 +16,7 @@
 - update build badge to use GitHub Action status (#109)
 - Migrate to GitHub Actions to gate PRs. (#105)
 - bumps actions/checkout from 2 to 3 (#119)
+- addon-manager refactor pkg/ directory (#123)
 
 <a name="v0.4.3"></a>
 ## [v0.4.3] - 2021-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Migrate to GitHub Actions to gate PRs. (#105)
 - bumps actions/checkout from 2 to 3 (#119)
 - addon-manager refactor pkg/ directory (#123)
+- Bump actions/setup-go from 2 to 3 (#132)
+- Bump codecov/codecov-action from 2.1.0 to 3 (#128)
 
 <a name="v0.4.3"></a>
 ## [v0.4.3] - 2021-07-15


### PR DESCRIPTION
## [v0.5.0] - 2022-04-26
### Fixed
- Build Fix (#102)
- Fix UTC build date (#135)
### Changed
- Upgrade to Go 1.17+ (#116)
- Upgrade Kubernetes APIs (apimachinery, api, etc.) to 0.21 (#116)
- Upgrade Argo to v3.2.6 (#116)
- move api/v1alpha1 to api/addon/v1alpha1; add "comment marker" (#116)
- use code-generator generate API(s) clientset/informer/listers and put into pkg/client directory. (#116)
- add code-generator into Makefile generate (#116)
- update build badge to use GitHub Action status (#109)
- Migrate to GitHub Actions to gate PRs. (#105)
- bumps actions/checkout from 2 to 3 (#119)
- addon-manager refactor pkg/ directory (#123)
- Bump actions/setup-go from 2 to 3 (#132)
- Bump codecov/codecov-action from 2.1.0 to 3 (#128)


Signed-off-by: kevdowney <kevdowney@gmail.com>