### PR TITLE
Bump version and CHANGELOG for v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+<a name="v0.5.2"></a>
+## [v0.5.2] - 2022-06-07
+### Fixed
+- Fix workflow controller watcher and rbac (#147)
+
 <a name="v0.5.1"></a>
 ## [v0.5.1] - 2022-05-31
 ### Fixed
@@ -107,7 +112,8 @@
 ### Added
 - Initial Release of Addon Manager
 
-[Unreleased]: https://github.com/keikoproj/addon-manager/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/keikoproj/addon-manager/compare/v0.5.2...HEAD
+[v0.5.2]: https://github.com/keikoproj/addon-manager/compare/v0.5.1...v0.5.2
 [v0.5.1]: https://github.com/keikoproj/addon-manager/compare/v0.5.0...v0.5.1
 [v0.5.0]: https://github.com/keikoproj/addon-manager/compare/v0.4.3...v0.5.0
 [v0.4.3]: https://github.com/keikoproj/addon-manager/compare/v0.4.2...v0.4.3

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,7 +19,7 @@ import "fmt"
 // The below variables will be overrriden using ldflags set by goreleaser during the build process
 var (
 	// Version is the version string
-	Version = "v0.5.1"
+	Version = "v0.5.2"
 
 	// GitCommit is the git commit hash
 	GitCommit = "NONE"


### PR DESCRIPTION
## [v0.5.2] - 2022-06-07
### Fixed
- Fix workflow controller watcher and rbac (#147)

Signed-off-by: kevdowney <kevdowney@gmail.com>