### PR TITLE
Limit workflow watches to namespace scope

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,14 +58,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - argoproj.io
-  resources:
-  - workflows
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - batch
   resources:
   - cronjobs

--- a/controllers/addon_controller.go
+++ b/controllers/addon_controller.go
@@ -105,7 +105,6 @@ func NewAddonReconciler(mgr manager.Manager, dynClient dynamic.Interface, wfInf 
 
 // +kubebuilder:rbac:groups=addonmgr.keikoproj.io,resources=addons,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=addonmgr.keikoproj.io,resources=addons/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=argoproj.io,resources=workflows,namespace=system,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,namespace=system,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=list
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;patch;create

--- a/controllers/workflow_controller.go
+++ b/controllers/workflow_controller.go
@@ -25,12 +25,9 @@ import (
 	addonv1 "github.com/keikoproj/addon-manager/api/addon/v1alpha1"
 	pkgaddon "github.com/keikoproj/addon-manager/pkg/addon"
 	"k8s.io/client-go/dynamic"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -57,15 +54,12 @@ func NewWFController(mgr manager.Manager, dynClient dynamic.Interface, addonvers
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&wfv1.Workflow{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(w client.Object) bool {
-			// Only watch workflows in addon-manager-system namespace
-			return w.GetNamespace() == addonapiv1.ManagedNameSpace
-		}))).
+		For(&wfv1.Workflow{}).
 		WithOptions(controller.Options{CacheSyncTimeout: addonapiv1.CacheSyncTimeout}).
 		Complete(r)
 }
 
-// +kubebuilder:rbac:groups=argoproj.io,resources=workflows,verbs=get;list;watch
+// +kubebuilder:rbac:groups=argoproj.io,resources=workflows,namespace=system,verbs=get;list;watch;create;update;patch;delete
 
 func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	wfobj := &wfv1.Workflow{}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/keikoproj/addon-manager/api/addon"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -52,6 +53,7 @@ func main() {
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "addonmgr.keikoproj.io",
+		Namespace:          addon.ManagedNameSpace,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Fixes #151 

Limit Workflow watches and cache to `addon-manager-system` namespace.

Signed-off-by: kevdowney <kevdowney@gmail.com>