### PR TITLE
Remove verbose logging for workflow reconcile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+<a name="v0.6.2"></a>
+## [v0.6.2] - 2022-08-01
+### Fixed
+-  Remove verbose logging for workflow reconcile (#156)
+
 <a name="v0.6.1"></a>
 ## [v0.6.1] - 2022-08-01
 ### Fixed
@@ -122,7 +127,8 @@
 ### Added
 - Initial Release of Addon Manager
 
-[Unreleased]: https://github.com/keikoproj/addon-manager/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/keikoproj/addon-manager/compare/v0.6.2...HEAD
+[v0.6.2]: https://github.com/keikoproj/addon-manager/compare/v0.6.1...v0.6.2
 [v0.6.1]: https://github.com/keikoproj/addon-manager/compare/v0.6.0...v0.6.1
 [v0.6.0]: https://github.com/keikoproj/addon-manager/compare/v0.5.2...v0.6.0
 [v0.5.2]: https://github.com/keikoproj/addon-manager/compare/v0.5.1...v0.5.2

--- a/controllers/workflow_controller.go
+++ b/controllers/workflow_controller.go
@@ -63,7 +63,6 @@ func NewWFController(mgr manager.Manager, dynClient dynamic.Interface, addonvers
 // +kubebuilder:rbac:groups=argoproj.io,resources=workflows,namespace=system,verbs=get;list;watch;create;update;patch;delete
 
 func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.log = r.log.WithValues("workflow", req.NamespacedName)
 	wfobj := &wfv1.Workflow{}
 	err := r.client.Get(ctx, req.NamespacedName, wfobj)
 	if apierrors.IsNotFound(err) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,7 +19,7 @@ import "fmt"
 // The below variables will be overrriden using ldflags set by goreleaser during the build process
 var (
 	// Version is the version string
-	Version = "v0.6.1"
+	Version = "v0.6.2"
 
 	// GitCommit is the git commit hash
 	GitCommit = "NONE"


### PR DESCRIPTION
## [v0.6.2] - 2022-08-01
### Fixed
-  Remove verbose logging for workflow reconcile (#156)

Signed-off-by: kevdowney <kevdowney@gmail.com>