### PR TITLE
Restore goreleaser snapshot builds on master

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,11 @@ jobs:
   release:
     if: github.repository_owner == 'keikoproj'
     runs-on: ubuntu-latest
+    env:
+      flags: ""
     steps:
+      - if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: echo "flags=--snapshot" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v3.3.0
         with:
@@ -20,6 +24,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.17
+          cache: true
 
       - name: Download Kubebuilder
         run: |
@@ -51,6 +56,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist -f .goreleaser.yml
+          args: release --rm-dist ${{ env.flags }} -f .goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Goreleaser removed auto snapshot v4 so we need to restore it via detection, snapshots should be done for non-release builds in master.

Signed-off-by: kevdowney <kevdowney@gmail.com>