### PR TITLE
Add Admins ownership over CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,14 @@
 # the repo. Unless a later match takes precedence,
 # review when someone opens a pull request.
 *       @keikoproj/authorized-approvers
+
+# Admins own CI.
+.github/** @keikoproj/addon-manager-maintainers
+Makefile @keikoproj/addon-manager-maintainers
+Dockerfile @keikoproj/addon-manager-maintainers
+.editorconfig @keikoproj/addon-manager-maintainers
+.gitignore @keikoproj/addon-manager-maintainers
+.goreleaser.yml @keikoproj/addon-manager-maintainers
+.envrc @keikoproj/addon-manager-maintainers
+codecov.yml @keikoproj/addon-manager-maintainers
+/PROJECT @keikoproj/addon-manager-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,13 +8,6 @@
 # review when someone opens a pull request.
 *       @keikoproj/authorized-approvers
 
-# Admins own CI.
+# Admins own root and CI.
 .github/** @keikoproj/addon-manager-maintainers
-Makefile @keikoproj/addon-manager-maintainers
-Dockerfile @keikoproj/addon-manager-maintainers
-.editorconfig @keikoproj/addon-manager-maintainers
-.gitignore @keikoproj/addon-manager-maintainers
-.goreleaser.yml @keikoproj/addon-manager-maintainers
-.envrc @keikoproj/addon-manager-maintainers
-codecov.yml @keikoproj/addon-manager-maintainers
-/PROJECT @keikoproj/addon-manager-maintainers
+/*     @keikoproj/addon-manager-maintainers


### PR DESCRIPTION
Adds addon-manager-maintainers as CI owners.

Signed-off-by: kevdowney <kevdowney@gmail.com>