### PR TITLE
Update dependabot config to check packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule: 
+      interval: "weekly"


### PR DESCRIPTION
Adds `gomod` and `docker` package ecosystem checks.

Signed-off-by: Kevin Downey <kevdowney@gmail.com>