### PR TITLE
chore: Allow only direct dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    allow: 
+      - dependency-type: "direct"
   - package-ecosystem: "docker"
     directory: "/"
     schedule: 


### PR DESCRIPTION
Allows only direct dependencies listed in `go.mod` to be updated.