### PR TITLE
chore: Dep bot ignore semver major minor k8s

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "golang"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    allow: 
+    allow:
       - dependency-type: "direct"
+    ignore:
+      - dependency-name: "k8s.io*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "docker"
     directory: "/"
-    schedule: 
+    schedule:
       interval: "weekly"


### PR DESCRIPTION
Update dependabot config to:
- Ignore major and minor updates for core `k8s.io` dependencies.
- Ignore major updates for `all` dependencies.
- Ignore Docker `golang` updates.

