### PR TITLE
chore: Update dependabot config to ignore major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    allow: 
+    allow:
       - dependency-type: "direct"
+    ignore:
+      - dependency-name: "k8s.io*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "docker"
     directory: "/"
-    schedule: 
+    schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "golang"


### PR DESCRIPTION
Update dependabot config to:
- Ignore major and minor updates for core `k8s.io` dependencies.
- Ignore major updates for `all` dependencies.
- Ignore Docker `golang` updates.
