### PR TITLE
Recover from panics in addon workflow controller

### DIFF
--- a/controllers/workflow_controller.go
+++ b/controllers/workflow_controller.go
@@ -85,6 +85,11 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	owner := metav1.GetControllerOf(wfobj)
+	if owner == nil {
+		err := fmt.Errorf("workflow %s/%s has no owner", wfobj.GetNamespace(), wfobj.GetName())
+		r.log.Error(err, wfobj.GetNamespace(), wfobj.GetName(), " owner is empty")
+		return ctrl.Result{}, err
+	}
 	if owner.Kind != "Addon" {
 		r.log.Info("workflow ", wfobj.GetNamespace(), wfobj.GetName(), " owner ", owner.Kind, " is not an addon")
 		return ctrl.Result{}, nil

--- a/controllers/workflow_controller.go
+++ b/controllers/workflow_controller.go
@@ -59,6 +59,11 @@ func NewWFController(mgr manager.Manager, dynClient dynamic.Interface, addonUpda
 // +kubebuilder:rbac:groups=argoproj.io,resources=workflows,namespace=system,verbs=get;list;watch;create;update;patch;delete
 
 func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			r.log.Info(fmt.Sprintf("Error: Panic occurred when reconciling %s due to %v", req.String(), err))
+		}
+	}()
 	wfobj := &wfv1.Workflow{}
 	err := r.client.Get(ctx, req.NamespacedName, wfobj)
 	if apierrors.IsNotFound(err) {

--- a/controllers/workflow_controller_test.go
+++ b/controllers/workflow_controller_test.go
@@ -1,0 +1,53 @@
+package controllers
+
+import (
+	"testing"
+	"time"
+
+	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	logrtesting "github.com/go-logr/logr/testing"
+	addonmgrv1alpha1 "github.com/keikoproj/addon-manager/api/addon/v1alpha1"
+	pkgaddon "github.com/keikoproj/addon-manager/pkg/addon"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	testScheme = runtime.NewScheme()
+	rcdr       = record.NewBroadcasterForTests(1*time.Second).NewRecorder(testScheme, v1.EventSource{Component: "addons"})
+)
+
+func init() {
+	_ = addonmgrv1alpha1.AddToScheme(testScheme)
+	_ = wfv1.AddToScheme(testScheme)
+	_ = clientgoscheme.AddToScheme(testScheme)
+}
+
+func TestWorkflowReconciler_Reconcile(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	fakeCli := fake.NewClientBuilder().WithScheme(testScheme).WithObjects().Build()
+	dynFakeCli := dynfake.NewSimpleDynamicClient(testScheme)
+	log := logrtesting.TestLogger{T: t}
+	addonUpdater := pkgaddon.NewAddonUpdater(rcdr, fakeCli, pkgaddon.NewAddonVersionCacheClient(), log)
+
+	r := &WorkflowReconciler{
+		client:       fakeCli,
+		dynClient:    dynFakeCli,
+		log:          log,
+		addonUpdater: addonUpdater,
+	}
+
+	res, err := r.Reconcile(ctx, controllerruntime.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "test"}})
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(res).To(gomega.Equal(controllerruntime.Result{}))
+}

--- a/controllers/workflow_controller_test.go
+++ b/controllers/workflow_controller_test.go
@@ -134,7 +134,7 @@ func TestWorkflowReconciler_Reconcile_OwnerrefNotAddon(t *testing.T) {
 	fakeCli := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(wf).Build()
 	dynFakeCli := dynfake.NewSimpleDynamicClient(testScheme)
 	testLog := logrtesting.TestLogger{T: t}
-	addonUpdater := pkgaddon.NewDefaultAddonUpdater(rcdr, fakeCli, pkgaddon.NewAddonVersionCacheClient(), testLog)
+	addonUpdater := pkgaddon.NewAddonUpdater(rcdr, fakeCli, pkgaddon.NewAddonVersionCacheClient(), testLog)
 
 	r := &WorkflowReconciler{
 		client:       fakeCli,


### PR DESCRIPTION
Fixes #219 

- Recover from panics.
- Handle `nil` values from ownerrefs.
- Add workflow controller tests.