### PR TITLE
chore: ignore sigs.k8s.io minor version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
     ignore:
       - dependency-name: "k8s.io*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "sigs.k8s.io*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
   - package-ecosystem: "docker"


### PR DESCRIPTION
Ignore the major and minor version upgrades for packages in `sigs.k8s.io` e.g., `controller-runtime`.