### PR TITLE
Push image with tag 'latest' on merge to master

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -74,13 +74,3 @@ jobs:
       - name: Build
         run: |
           make docker-build
-
-      - name: Build and push Docker image with tag 'latest' (only on merge to master)
-        if: github.event_name == 'push' && github.repository == 'keikoproj/addon-manager'
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
-          push: true
-          tags: keikoproj/addon-manager:latest

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -74,3 +74,13 @@ jobs:
       - name: Build
         run: |
           make docker-build
+
+      - name: Build and push Docker image with tag 'latest' (only on merge to master)
+        if: github.event_name == 'push' && github.repository == 'keikoproj/addon-manager'
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          tags: keikoproj/addon-manager:latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -132,3 +132,7 @@ docker_manifests:
     image_templates:
       - "keikoproj/addon-manager:v{{ .Version }}-amd64"
       - "keikoproj/addon-manager:v{{ .Version }}-arm64"
+  - name_template: "keikoproj/addon-manager:latest"
+    image_templates:
+      - "keikoproj/addon-manager:v{{ .Version }}-amd64"
+      - "keikoproj/addon-manager:v{{ .Version }}-arm64"


### PR DESCRIPTION
Noticed the [`latest` Docker image](https://hub.docker.com/repository/docker/keikoproj/addon-manager/tags?page=1&ordering=last_updated&name=latest) in docker hub is very old. Add this so `latest` is pushed after each merge to master.