### PR TITLE
fix: remove old workflows on addon checksum change

### DIFF
--- a/pkg/workflows/workflow.go
+++ b/pkg/workflows/workflow.go
@@ -121,6 +121,7 @@ func (w *workflowLifecycle) Install(ctx context.Context, wp *WorkflowProxy) erro
 	}
 
 	w.injectInstanceId(wf)
+	w.addDefaultLabelsToResource(wf)
 
 	return w.submit(ctx, wf)
 }


### PR DESCRIPTION
fixes: #285 #174 

with contribution from @estela-ramirez 

a new addon (but has the same checksum from recent past) won't generate a new workflow since a previous workflow was already created; as a result, the addon gets stuck on pending

fix is to purge old workflows so a new workflow can get created